### PR TITLE
Fix reCAPTCHA container handling

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -145,6 +145,15 @@ async function sendSMS(rawPhone) {
     window.recaptchaVerifier = null;
   }
 
+  // Garante que o elemento do reCAPTCHA exista
+  let recEl = document.getElementById('recaptcha-container');
+  if (!recEl) {
+    recEl = document.createElement('div');
+    recEl.id = 'recaptcha-container';
+    const btnGroup = document.querySelector('.button-group');
+    btnGroup?.parentNode.insertBefore(recEl, btnGroup);
+  }
+
   // Cria novo reCAPTCHA invisível
   window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier('recaptcha-container', {
     size: 'invisible',

--- a/public/chat.js
+++ b/public/chat.js
@@ -167,6 +167,15 @@ async function sendSMS(phone) {
     window.recaptchaVerifier = null;
   }
 
+  // Garante que o elemento do reCAPTCHA exista
+  let recEl = document.getElementById('recaptcha-container');
+  if (!recEl) {
+    recEl = document.createElement('div');
+    recEl.id = 'recaptcha-container';
+    const btnGroup = document.querySelector('.button-group');
+    btnGroup?.parentNode.insertBefore(recEl, btnGroup);
+  }
+
   // Criar novo reCAPTCHA
   window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier('recaptcha-container', {
     'size': 'invisible',


### PR DESCRIPTION
## Summary
- ensure the Recaptcha DOM node exists when sending SMS

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687584c63a908323b71e812e2c3d569e