### PR TITLE
Fix message count for new users

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -55,22 +55,21 @@ export default async function handler(req, res) {
             uid,
             email,
             plano: 'gratis',
-            mensagensRestantes: 9,
+            mensagensRestantes: 10,
             dataUltimoReset: now,
             createdAt: now,
           };
           tx.set(userRef, userData);
-          return;
-        }
-
-        userData = snap.data();
-        const lastReset = userData.dataUltimoReset?.toDate().toDateString();
-        if (lastReset !== today) {
-          userData.mensagensRestantes = 10;
-          tx.update(userRef, {
-            mensagensRestantes: 10,
-            dataUltimoReset: now,
-          });
+        } else {
+          userData = snap.data();
+          const lastReset = userData.dataUltimoReset?.toDate().toDateString();
+          if (lastReset !== today) {
+            userData.mensagensRestantes = 10;
+            tx.update(userRef, {
+              mensagensRestantes: 10,
+              dataUltimoReset: now,
+            });
+          }
         }
 
         if (userData.plano === 'gratis' && userData.mensagensRestantes <= 0) {


### PR DESCRIPTION
## Summary
- ensure new users start with 10 messages and debit the first

## Testing
- `npm run` *(shows available npm scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6875a5fe40008323b8af572743428770