### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -118,6 +118,23 @@ export default async function handler(req, res) {
       body: JSON.stringify(requestBody),
     });
 
+    if (!openaiRes.ok) {
+      console.error('❌ OpenAI status:', openaiRes.status);
+      try {
+        const err = await openaiRes.json();
+        console.error('❌ OpenAI error:', err);
+        return res.status(502).json({
+          error: 'Falha ao consultar OpenAI',
+          details: err.error?.message || JSON.stringify(err),
+        });
+      } catch (e) {
+        return res.status(502).json({
+          error: 'Falha ao consultar OpenAI',
+          details: `Status ${openaiRes.status}`,
+        });
+      }
+    }
+
     const data = await openaiRes.json();
 
     if (!data.choices || !data.choices[0]?.message) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vercel dev",
-    "start": "node api/chat.js"
+    "start": "node api/chat.js",
+    "test": "jest"
   },
   "dependencies": {
     "dotenv": "^16.4.5",
@@ -19,7 +20,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "serve": "^14.2.4"
+    "serve": "^14.2.4",
+    "jest": "^29.7.0"
   },
   "repository": {
     "type": "git",

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -1,0 +1,74 @@
+import handler from '../api/chat.js';
+
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: jest.fn(),
+  cert: jest.fn(),
+  getApps: jest.fn(() => [])
+}));
+
+jest.mock('firebase-admin/auth', () => ({
+  getAuth: () => ({
+    verifyIdToken: jest.fn(() => Promise.resolve({ uid: '1', email: 't@example.com' }))
+  })
+}));
+
+jest.mock('firebase-admin/firestore', () => ({
+  getFirestore: () => ({
+    collection: jest.fn().mockReturnThis(),
+    doc: jest.fn().mockReturnThis(),
+    runTransaction: jest.fn(async fn => {
+      await fn({
+        get: jest.fn(() => ({ exists: false })),
+        set: jest.fn(),
+        update: jest.fn()
+      });
+    })
+  }),
+  FieldValue: { increment: jest.fn() },
+  Timestamp: { now: () => ({ toDate: () => new Date() }) }
+}));
+
+function createRes() {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  res.end = jest.fn(() => res);
+  return res;
+}
+
+describe('chat handler', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns reply on success', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ choices: [{ message: { content: 'hi' } }] })
+    });
+
+    const req = { method: 'POST', body: { message: 'Hello', idToken: 'tok', conversationHistory: [] } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ reply: 'hi' });
+  });
+
+  it('handles openai failure', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: { message: 'bad' } })
+    });
+
+    const req = { method: 'POST', body: { message: 'Hello', idToken: 'tok', conversationHistory: [] } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json.mock.calls[0][0].error).toBe('Falha ao consultar OpenAI');
+  });
+});


### PR DESCRIPTION
## Summary
- handle OpenAI failures in `api/chat.js`
- add `jest` and unit tests for success and failure

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875aaa741848323abc8860eeaf81d3d