### PR TITLE
Improve env validation and error logs

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -7,6 +7,11 @@ let firebaseInitialized = false;
 async function initializeFirebase() {
   if (firebaseInitialized || getApps().length > 0) return;
 
+  if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
+    console.error('FIREBASE_SERVICE_ACCOUNT environment variable is missing.');
+    throw new Error('Firebase service account not configured');
+  }
+
   const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
 
   initializeApp({
@@ -109,6 +114,11 @@ export default async function handler(req, res) {
       ],
     };
 
+    if (!process.env.OPENAI_API_KEY) {
+      console.error('OPENAI_API_KEY environment variable is missing.');
+      return res.status(500).json({ error: 'OpenAI API key not configured' });
+    }
+
     const openaiRes = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -135,6 +145,7 @@ export default async function handler(req, res) {
 
   } catch (error) {
     console.error('💥 ERRO NO SERVIDOR:', error);
+    console.error(error);
     return res.status(500).json({ error: 'Erro interno', details: error.message });
   }
 }


### PR DESCRIPTION
## Summary
- validate `FIREBASE_SERVICE_ACCOUNT` inside `initializeFirebase`
- check for `OPENAI_API_KEY` before calling OpenAI
- log full error stack in chat API catch block

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875ac95f0008323a26e13d909e4f806