### PR TITLE
Fix daily limit logic and show backend errors

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -60,17 +60,16 @@ export default async function handler(req, res) {
             createdAt: now,
           };
           tx.set(userRef, userData);
-          return;
-        }
-
-        userData = snap.data();
-        const lastReset = userData.dataUltimoReset?.toDate().toDateString();
-        if (lastReset !== today) {
-          userData.mensagensRestantes = 10;
-          tx.update(userRef, {
-            mensagensRestantes: 10,
-            dataUltimoReset: now,
-          });
+        } else {
+          userData = snap.data();
+          const lastReset = userData.dataUltimoReset?.toDate().toDateString();
+          if (lastReset !== today) {
+            userData.mensagensRestantes = 10;
+            tx.update(userRef, {
+              mensagensRestantes: 10,
+              dataUltimoReset: now,
+            });
+          }
         }
 
         if (userData.plano === 'gratis' && userData.mensagensRestantes <= 0) {

--- a/public/script.js
+++ b/public/script.js
@@ -178,17 +178,13 @@ async function processMessage(message) {
       body: JSON.stringify({ message, conversationHistory, idToken })
     });
 
-    let data;
-    if (response.ok) {
+      let data;
       const rawText = await response.text();
       try {
         data = JSON.parse(rawText);
       } catch (parseError) {
-        data = { error: 'Erro ao processar resposta' };
+        data = { error: rawText || 'Erro ao processar resposta' };
       }
-    } else {
-      data = { error: 'limite diário' };
-    }
 
     hideTypingIndicator();
 


### PR DESCRIPTION
## Summary
- remove early return when creating users so message decrement applies
- surface backend error responses in the chat UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875af5618708323ae43667ecd2ec18c