### PR TITLE
Fix OpenAI error handling

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -60,7 +60,6 @@ export default async function handler(req, res) {
             createdAt: now,
           };
           tx.set(userRef, userData);
-          return;
         }
 
         userData = snap.data();
@@ -117,6 +116,13 @@ export default async function handler(req, res) {
       },
       body: JSON.stringify(requestBody),
     });
+
+    if (!openaiRes.ok) {
+      console.error('❌ OpenAI status:', openaiRes.status);
+      return res
+        .status(502)
+        .json({ error: 'Erro na OpenAI', status: openaiRes.status });
+    }
 
     const data = await openaiRes.json();
 

--- a/public/script.js
+++ b/public/script.js
@@ -179,15 +179,11 @@ async function processMessage(message) {
     });
 
     let data;
-    if (response.ok) {
-      const rawText = await response.text();
-      try {
-        data = JSON.parse(rawText);
-      } catch (parseError) {
-        data = { error: 'Erro ao processar resposta' };
-      }
-    } else {
-      data = { error: 'limite diário' };
+    const rawText = await response.text();
+    try {
+      data = JSON.parse(rawText);
+    } catch (parseError) {
+      data = { error: 'Erro ao processar resposta' };
     }
 
     hideTypingIndicator();
@@ -198,6 +194,8 @@ async function processMessage(message) {
         `🔓 <a href="planos.html" class="btn-plus" target="_blank">Assinar versão Plus</a>`,
         'bot'
       );
+    } else if (!response.ok) {
+      appendMessage(`<strong>Assistente:</strong> ${data.error || 'Ocorreu um erro inesperado.'}`, 'bot');
     } else if (data.reply) {
       appendMessage(`<strong>Assistente:</strong> ${data.reply}`, 'bot');
       conversationHistory.push({ role: 'assistant', content: data.reply });


### PR DESCRIPTION
## Summary
- let transaction finish for new users
- check `openaiRes.ok` and return a 502 when OpenAI fails
- show API error details in the client script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875b1560c448323898db730fb39f77d