### PR TITLE
Handle OpenAI error responses

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -118,7 +118,20 @@ export default async function handler(req, res) {
       body: JSON.stringify(requestBody),
     });
 
-    const data = await openaiRes.json();
+    if (!openaiRes.ok) {
+      console.error('❌ Erro da OpenAI:', openaiRes.status);
+      return res
+        .status(502)
+        .json({ error: 'Erro na OpenAI', status: openaiRes.status });
+    }
+
+    let data;
+    try {
+      data = await openaiRes.json();
+    } catch (err) {
+      console.error('❌ Erro ao processar JSON da OpenAI:', err);
+      return res.status(500).json({ error: 'Resposta inválida da OpenAI' });
+    }
 
     if (!data.choices || !data.choices[0]?.message) {
       console.error("❌ Resposta inválida da OpenAI:", data);


### PR DESCRIPTION
## Summary
- avoid parsing OpenAI response when status is not OK
- return 502 errors with the upstream status
- catch JSON parsing issues

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875b370579c8323ac71e5db2d4ba377