### PR TITLE
Fix new user transaction decrement

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -50,7 +50,17 @@ export default async function handler(req, res) {
         const now = Timestamp.now();
         const today = now.toDate().toDateString();
 
-        if (!snap.exists) {
+        if (snap.exists) {
+          userData = snap.data();
+          const lastReset = userData.dataUltimoReset?.toDate().toDateString();
+          if (lastReset !== today) {
+            userData.mensagensRestantes = 10;
+            tx.update(userRef, {
+              mensagensRestantes: 10,
+              dataUltimoReset: now,
+            });
+          }
+        } else {
           userData = {
             uid,
             email,
@@ -60,17 +70,6 @@ export default async function handler(req, res) {
             createdAt: now,
           };
           tx.set(userRef, userData);
-          return;
-        }
-
-        userData = snap.data();
-        const lastReset = userData.dataUltimoReset?.toDate().toDateString();
-        if (lastReset !== today) {
-          userData.mensagensRestantes = 10;
-          tx.update(userRef, {
-            mensagensRestantes: 10,
-            dataUltimoReset: now,
-          });
         }
 
         if (userData.plano === 'gratis' && userData.mensagensRestantes <= 0) {

--- a/tests/newUserMessageTest.js
+++ b/tests/newUserMessageTest.js
@@ -1,0 +1,41 @@
+import { Timestamp } from 'firebase-admin/firestore';
+
+async function runTransaction() {
+  let userRef = { data: null };
+  let userData;
+  const snapExists = userRef.data !== null;
+  const now = Timestamp.now();
+  const today = now.toDate().toDateString();
+
+  if (snapExists) {
+    userData = userRef.data;
+    const lastReset = userData.dataUltimoReset?.toDate().toDateString();
+    if (lastReset !== today) {
+      userData.mensagensRestantes = 10;
+      userRef.data.mensagensRestantes = 10;
+      userRef.data.dataUltimoReset = now;
+    }
+  } else {
+    userData = {
+      uid: 'test-uid',
+      email: 'test@example.com',
+      plano: 'gratis',
+      mensagensRestantes: 10,
+      dataUltimoReset: now,
+      createdAt: now,
+    };
+    userRef.data = { ...userData };
+  }
+
+  if (userData.plano === 'gratis' && userData.mensagensRestantes <= 0) {
+    throw new Error('LIMIT');
+  }
+
+  userRef.data.mensagensRestantes -= 1;
+  userData.mensagensRestantes = userRef.data.mensagensRestantes;
+  return userData;
+}
+
+runTransaction().then(res => {
+  console.log('Mensagens restantes apos primeira requisicao:', res.mensagensRestantes);
+});


### PR DESCRIPTION
## Summary
- ensure the chat transaction continues after creating a user
- add a small script to demonstrate remaining quota for a new user

## Testing
- `npm test` *(fails: Missing script)*
- `node tests/newUserMessageTest.js`

------
https://chatgpt.com/codex/tasks/task_e_6875b35d68348323aea23de06d152533