### PR TITLE
Improve env validation and logging in chat handler

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -7,6 +7,11 @@ let firebaseInitialized = false;
 async function initializeFirebase() {
   if (firebaseInitialized || getApps().length > 0) return;
 
+  if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
+    console.error('FIREBASE_SERVICE_ACCOUNT environment variable is not set');
+    throw new Error('FIREBASE_SERVICE_ACCOUNT missing');
+  }
+
   const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
 
   initializeApp({
@@ -109,6 +114,11 @@ export default async function handler(req, res) {
       ],
     };
 
+    if (!process.env.OPENAI_API_KEY) {
+      console.error('OPENAI_API_KEY environment variable is not set');
+      return res.status(500).json({ error: 'OpenAI API key not configured' });
+    }
+
     const openaiRes = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -134,7 +144,8 @@ export default async function handler(req, res) {
     return res.status(200).json({ reply });
 
   } catch (error) {
-    console.error('💥 ERRO NO SERVIDOR:', error);
+    console.error('💥 ERRO NO SERVIDOR:', error.message);
+    console.error(error);
     return res.status(500).json({ error: 'Erro interno', details: error.message });
   }
 }


### PR DESCRIPTION
## Summary
- validate FIREBASE_SERVICE_ACCOUNT when initializing Firebase
- ensure OPENAI_API_KEY is set before contacting OpenAI
- include stack trace in error logs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875b39ed17483238331b8c790c37609