### PR TITLE
Implement onboarding for new users

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -130,7 +130,8 @@ async function handleUserLimits(db, uid, email) {
 
 
 // Função para chamar a API da OpenAI
-async function callOpenAI(messages) {
+async function callOpenAI(messages, perfil) {
+  const perfilText = perfil ? `\nDados do usuário:\n- Nível: ${perfil.nivel}\n- DAW: ${perfil.daw}\n- Gênero: ${perfil.genero}\n- Desafio principal: ${perfil.desafio}\nUse essas informações para personalizar as respostas.` : '';
   const requestBody = {
     model: 'gpt-3.5-turbo',
     temperature: 0.7,
@@ -219,7 +220,7 @@ async function callOpenAI(messages) {
 • Abordagem profissional
 • Foco em resultados sonoros
 • Adaptação ao nível do usuário
-Seu foco é: melhorar o som do usuário, aprofundar sua visão técnica e ajudá-lo a crescer artisticamente.
+Seu foco é: melhorar o som do usuário, aprofundar sua visão técnica e ajudá-lo a crescer artisticamente.${perfilText}
 `
       },
       ...messages,
@@ -324,7 +325,7 @@ export default async function handler(req, res) {
     ];
 
     // 6. Chamar OpenAI
-    const reply = await callOpenAI(messages);
+    const reply = await callOpenAI(messages, userData.perfil);
 
     // 7. Log de sucesso
     if (userData.plano === 'gratis') {

--- a/public/auth.js
+++ b/public/auth.js
@@ -255,6 +255,29 @@ function checkAuthState() {
     auth.onAuthStateChanged(async (user) => {
       clearTimeout(timeout);
       const isLoginPage = window.location.pathname.includes("login.html");
+      const isProfilePage = window.location.pathname.includes("onboarding.html");
+
+      if (user && !isLoginPage && !isProfilePage) {
+        try {
+          const snap = await db.collection('usuarios').doc(user.uid).get();
+          if (!snap.data()?.perfil) {
+            window.location.href = 'onboarding.html';
+            return resolve(user);
+          }
+        } catch (e) {
+          console.error('Erro ao verificar perfil:', e);
+        }
+      } else if (user && isProfilePage) {
+        try {
+          const snap = await db.collection('usuarios').doc(user.uid).get();
+          if (snap.data()?.perfil) {
+            window.location.href = 'index.html';
+            return resolve(user);
+          }
+        } catch (e) {
+          console.error('Erro ao verificar perfil:', e);
+        }
+      }
 
       if (!user && !isLoginPage) {
         window.location.href = "login.html";

--- a/public/onboarding.html
+++ b/public/onboarding.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Prod.AI – Perfil</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="particles"></div>
+  <div class="container fade-in onboarding-container">
+    <div class="question-step" data-step="1">
+      <h2>1. Qual seu nível técnico em produção musical?</h2>
+      <div class="question-option"><label><input type="radio" name="nivel" value="Iniciante – estou começando agora">Iniciante – estou começando agora</label></div>
+      <div class="question-option"><label><input type="radio" name="nivel" value="Intermediário – já produzo, mas quero melhorar">Intermediário – já produzo, mas quero melhorar</label></div>
+      <div class="question-option"><label><input type="radio" name="nivel" value="Avançado – produzo, mixo e lanço com frequência">Avançado – produzo, mixo e lanço com frequência</label></div>
+      <div class="btn-center-wrapper"><button class="btn-plus next-btn">Próximo</button></div>
+    </div>
+    <div class="question-step" data-step="2">
+      <h2>2. Qual DAW você usa como principal?</h2>
+      <div class="question-option"><label><input type="radio" name="daw" value="FL Studio">FL Studio</label></div>
+      <div class="question-option"><label><input type="radio" name="daw" value="Ableton Live">Ableton Live</label></div>
+      <div class="question-option"><label><input type="radio" name="daw" value="Logic Pro">Logic Pro</label></div>
+      <div class="question-option"><label><input type="radio" name="daw" value="Pro Tools">Pro Tools</label></div>
+      <div class="question-option"><label><input type="radio" name="daw" value="Acid">Acid</label></div>
+      <div class="question-option"><label><input type="radio" name="daw" value="Outra">Outra</label></div>
+      <div class="btn-center-wrapper"><button class="btn-plus next-btn">Próximo</button></div>
+    </div>
+    <div class="question-step" data-step="3">
+      <h2>3. Qual seu gênero musical principal?</h2>
+      <div class="question-option"><label><input type="radio" name="genero" value="Funk">Funk</label></div>
+      <div class="question-option"><label><input type="radio" name="genero" value="Trap / Hip Hop">Trap / Hip Hop</label></div>
+      <div class="question-option"><label><input type="radio" name="genero" value="Eletrônica / EDM">Eletrônica / EDM</label></div>
+      <div class="question-option"><label><input type="radio" name="genero" value="Lo-fi / Chill">Lo-fi / Chill</label></div>
+      <div class="question-option"><label><input type="radio" name="genero" value="Trance">Trance</label></div>
+      <div class="question-option"><label><input type="radio" name="genero" value="Outro">Outro</label></div>
+      <div class="btn-center-wrapper"><button class="btn-plus next-btn">Próximo</button></div>
+    </div>
+    <div class="question-step" data-step="4">
+      <h2>4. Qual seu maior desafio atual?</h2>
+      <div class="question-option"><label><input type="radio" name="desafio" value="Mixagem">Mixagem</label></div>
+      <div class="question-option"><label><input type="radio" name="desafio" value="Masterização">Masterização</label></div>
+      <div class="question-option"><label><input type="radio" name="desafio" value="Composição / arranjo">Composição / arranjo</label></div>
+      <div class="question-option"><label><input type="radio" name="desafio" value="Criação Beat">Criação Beat</label></div>
+      <div class="question-option"><label><input type="radio" name="desafio" value="Carreira / lançamentos / distribuição">Carreira / lançamentos / distribuição</label></div>
+      <div class="btn-center-wrapper"><button class="btn-plus next-btn">Próximo</button></div>
+    </div>
+    <div class="question-step" data-step="5">
+      <h2>5. Você já lançou músicas nas plataformas digitais?</h2>
+      <div class="question-option"><label><input type="radio" name="lancou" value="Sim">Sim</label></div>
+      <div class="question-option"><label><input type="radio" name="lancou" value="Não">Não</label></div>
+      <div class="question-option"><label><input type="radio" name="lancou" value="Ainda não, mas pretendo">Ainda não, mas pretendo</label></div>
+      <div class="btn-center-wrapper"><button class="btn-plus next-btn">Próximo</button></div>
+    </div>
+    <div class="question-step" data-step="6">
+      <h2>6. Você trabalha com música profissionalmente?</h2>
+      <div class="question-option"><label><input type="radio" name="trabalha" value="Sim, vivo disso">Sim, vivo disso</label></div>
+      <div class="question-option"><label><input type="radio" name="trabalha" value="Parcialmente (freelas, estúdio, etc.)">Parcialmente (freelas, estúdio, etc.)</label></div>
+      <div class="question-option"><label><input type="radio" name="trabalha" value="Ainda não, mas quero">Ainda não, mas quero</label></div>
+      <div class="question-option"><label><input type="radio" name="trabalha" value="Só por hobby">Só por hobby</label></div>
+      <div class="btn-center-wrapper"><button class="btn-plus" id="startBtn">Começar</button></div>
+    </div>
+  </div>
+
+  <script src="https://www.gstatic.com/firebasejs/10.3.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.3.1/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.3.1/firebase-firestore-compat.js"></script>
+  <script src="auth.js"></script>
+  <script src="profile.js"></script>
+</body>
+</html>

--- a/public/profile.js
+++ b/public/profile.js
@@ -1,0 +1,47 @@
+let currentStep = 0;
+let steps;
+
+function showStep(index) {
+  steps.forEach((step, i) => {
+    step.classList.toggle('active', i === index);
+  });
+}
+
+function validateStep(index) {
+  const step = steps[index];
+  if (!step) return false;
+  return !!step.querySelector('input:checked');
+}
+
+async function saveProfile() {
+  if (!validateStep(currentStep)) return;
+  const answers = {};
+  steps.forEach(step => {
+    const checked = step.querySelector('input:checked');
+    if (checked) answers[checked.name] = checked.value;
+  });
+  try {
+    await waitForFirebase();
+    const user = firebase.auth().currentUser;
+    if (!user) return;
+    await firebase.firestore().collection('usuarios').doc(user.uid).update({ perfil: answers });
+    window.location.href = 'index.html';
+  } catch (e) {
+    console.error('Erro ao salvar perfil', e);
+  }
+}
+
+function nextStep() {
+  if (!validateStep(currentStep)) return;
+  currentStep++;
+  if (currentStep >= steps.length) return;
+  showStep(currentStep);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  steps = Array.from(document.querySelectorAll('.question-step'));
+  showStep(currentStep);
+  document.querySelectorAll('.next-btn').forEach(btn => btn.addEventListener('click', nextStep));
+  const startBtn = document.getElementById('startBtn');
+  if (startBtn) startBtn.addEventListener('click', saveProfile);
+});

--- a/public/style.css
+++ b/public/style.css
@@ -915,3 +915,13 @@ footer {
   padding-left: 0; /* ou ajuste conforme a margem do seu input */
 }
 
+
+/* Onboarding */
+.onboarding-container { background: rgba(15,15,35,0.95); border: 1px solid rgba(147,51,234,0.3); border-radius: 24px; padding: 2rem; margin: 2rem auto; max-width: 600px; }
+.question-step { display: none; }
+.question-step.active { display: block; }
+.question-step h2 { color: #fff; margin-bottom: 1rem; font-size: 1.2rem; }
+.question-option { margin-bottom: 0.5rem; }
+.question-option label { color: #fff; cursor: pointer; }
+.question-option input { margin-right: 0.4rem; }
+


### PR DESCRIPTION
## Summary
- create onboarding.html to collect production profile info
- style onboarding steps in style.css
- add profile.js to handle onboarding flow
- redirect to onboarding in auth.js if profile missing
- pass user profile info to OpenAI request

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876d9f762488323a4201dc85f74ee19